### PR TITLE
Add output directory option and update sprint plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Useful flags:
 - `--categorize-agents` – add maturity/agent type details to classes
 - `--generate-init` – automatically create `__init__.py` files
 - `--no-chatgpt-context` – skip the ChatGPT context export
+- `--output-dir` – directory to store generated JSON reports
 
 To inspect the results visually, launch the GUI:
 

--- a/docs/SPRINT_TASKS.md
+++ b/docs/SPRINT_TASKS.md
@@ -1,16 +1,26 @@
 # Sprint Tasks
 
-This sprint focuses on polish and preparing for the next feature release.
+This sprint aims to move ProjectScanner toward a beta-ready release. The tasks below mirror the beta checklist so future agents can pick up each item.
 
 ## High Priority
-- [ ] Package tree-sitter grammars for Rust and JavaScript
-- [ ] Add CLI option to specify custom output directory
-- [ ] Expand unit test coverage for CLI and caching logic
+- [ ] Bundle tree-sitter grammars for Rust and JavaScript
+- [ ] Implement initial plugin architecture for additional languages
+- [ ] Expand complexity metrics and provide lint suggestions
+- [ ] Add CLI option to specify custom output directory *(in progress)*
+- [ ] Expand unit & integration test coverage for CLI and caching logic
+- [ ] Verify agent categorisation is included in reports
+- [ ] Validate `__init__.py` generation toggle works
+- [ ] Ensure ChatGPT context export succeeds
+- [ ] Update documentation for new CLI flags and plugin usage
 
 ## Medium Priority
 - [ ] Document setup of optional GUI in README
 - [ ] Provide example GitHub Actions workflow for automated scanning
+- [ ] Perform performance check on a medium-size project
+- [ ] Test the PyQt5 viewer with sample reports
 
 ## Low Priority
 - [ ] Research additional language parsers (e.g., Go, Java)
-- [ ] Explore improved complexity metrics or linter integration
+- [ ] Explore further complexity metrics or linter integration
+- [ ] Final release checklist once all tests pass
+

--- a/projectscanner/cli.py
+++ b/projectscanner/cli.py
@@ -27,9 +27,14 @@ def main():
     parser.add_argument(
         "--generate-init", action="store_true", help="Enable auto-generating __init__.py files."
     )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory to store generated JSON reports.",
+    )
     args = parser.parse_args()
 
-    scanner = ProjectScanner(project_root=args.project_root)
+    scanner = ProjectScanner(project_root=args.project_root, output_dir=args.output_dir)
     scanner.additional_ignore_dirs = set(args.ignore)
 
     scanner.scan_project()
@@ -49,7 +54,7 @@ def main():
         scanner.export_chatgpt_context()
         logging.info("✅ ChatGPT context exported by default.")
 
-        context_path = Path(args.project_root) / scanner.report_generator.context_file
+        context_path = scanner.output_dir / scanner.report_generator.context_file
         if context_path.exists():
             try:
                 with context_path.open("r", encoding="utf-8") as f:

--- a/projectscanner/report_generator.py
+++ b/projectscanner/report_generator.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 class ReportGenerator:
     """Handles merging new analysis with old reports."""
 
-    def __init__(self, project_root: Path, analysis: Dict[str, Dict]):
+    def __init__(self, project_root: Path, analysis: Dict[str, Dict], output_dir: Path | None = None):
         self.project_root = Path(project_root).resolve()
+        self.output_dir = Path(output_dir).resolve() if output_dir else self.project_root
         self.analysis = analysis
         name = re.sub(r"[^A-Za-z0-9_.-]", "_", self.project_root.name)
         self.analysis_file = f"project_analysis_{name}.json"
@@ -27,7 +28,7 @@ class ReportGenerator:
         return {}
 
     def save_report(self):
-        report_path = self.project_root / self.analysis_file
+        report_path = self.output_dir / self.analysis_file
         existing_report = self.load_existing_report(report_path)
         merged = {**existing_report, **self.analysis}
         try:
@@ -63,8 +64,8 @@ class ReportGenerator:
                 pass
         return {}
 
-    def export_chatgpt_context(self, template_path: str = None, output_path: str = None):
-        context_path = self.project_root / (output_path or self.context_file)
+    def export_chatgpt_context(self, template_path: str = None, output_path: str | None = None):
+        context_path = self.output_dir / (output_path or self.context_file)
         if template_path is None:
             existing_context = self.load_existing_chatgpt_context(context_path)
             payload = {

--- a/projectscanner/scanner.py
+++ b/projectscanner/scanner.py
@@ -16,8 +16,9 @@ logger = logging.getLogger(__name__)
 class ProjectScanner:
     """Main orchestrator for analyzing projects."""
 
-    def __init__(self, project_root: Union[str, Path] = "."):
+    def __init__(self, project_root: Union[str, Path] = ".", output_dir: Optional[Union[str, Path]] = None):
         self.project_root = Path(project_root).resolve()
+        self.output_dir = Path(output_dir).resolve() if output_dir else self.project_root
         self.analysis: Dict[str, Dict] = {}
         self.cache = self.load_cache()
         self.cache_lock = threading.Lock()
@@ -29,7 +30,7 @@ class ProjectScanner:
             self.cache_lock,
             self.additional_ignore_dirs,
         )
-        self.report_generator = ReportGenerator(self.project_root, self.analysis)
+        self.report_generator = ReportGenerator(self.project_root, self.analysis, self.output_dir)
 
     # --- Cache helpers ---
     def load_cache(self) -> Dict:
@@ -114,7 +115,7 @@ class ProjectScanner:
         self.save_cache()
         logger.info(
             "✅ Scan complete. Results merged into %s",
-            self.project_root / self.report_generator.analysis_file,
+            self.output_dir / self.report_generator.analysis_file,
         )
 
     def _process_file(self, file_path: Path):


### PR DESCRIPTION
## Summary
- allow specifying custom output directory for reports
- document the new `--output-dir` CLI flag
- update sprint tasks to reflect beta checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec82f6ea08329a77b106a28788a5a